### PR TITLE
#40 동호회 모임일정 API

### DIFF
--- a/.github/workflows/tofu-deploy.yml
+++ b/.github/workflows/tofu-deploy.yml
@@ -30,7 +30,7 @@ jobs:
             git pull
             cd docker
             echo '${{ secrets.DOCKERHUB_PASSWORD }}' | docker login -u ${{ secrets.DOCKERHUB_USER }} --password-stdin
-            sudo docker rm -f $(docker ps -q -a)
+            docker-compose down
             docker-compose pull
             docker-compose up -d
             docker image prune -f

--- a/src/main/java/com/hansol/tofu/applicant/ApplicantService.java
+++ b/src/main/java/com/hansol/tofu/applicant/ApplicantService.java
@@ -1,0 +1,18 @@
+package com.hansol.tofu.applicant;
+
+import java.sql.SQLException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hansol.tofu.applicant.repository.ApplicantRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(rollbackFor = SQLException.class)
+public class ApplicantService {
+
+	private final ApplicantRepository applicantRepository;
+}

--- a/src/main/java/com/hansol/tofu/applicant/ClubApplicationService.java
+++ b/src/main/java/com/hansol/tofu/applicant/ClubApplicationService.java
@@ -1,0 +1,21 @@
+package com.hansol.tofu.applicant;
+
+import java.sql.SQLException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hansol.tofu.clubschedule.ClubScheduleService;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(rollbackFor = SQLException.class)
+public class ClubApplicationService {
+
+	private final ApplicantService applicantService;
+	private final ClubScheduleService clubScheduleService;
+
+
+}

--- a/src/main/java/com/hansol/tofu/applicant/controller/ClubApplicationController.java
+++ b/src/main/java/com/hansol/tofu/applicant/controller/ClubApplicationController.java
@@ -1,0 +1,19 @@
+package com.hansol.tofu.applicant.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hansol.tofu.applicant.ClubApplicationService;
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@SecurityRequirement(name = "Bearer Authentication")
+@Tag(name = "applicant", description = "동호회 모임참가 API")
+@RestController
+@RequestMapping("/api/applicants")
+@RequiredArgsConstructor
+public class ClubApplicationController {
+	private final ClubApplicationService clubApplicationService;
+}

--- a/src/main/java/com/hansol/tofu/applicant/domain/ApplicantEntity.java
+++ b/src/main/java/com/hansol/tofu/applicant/domain/ApplicantEntity.java
@@ -1,0 +1,47 @@
+package com.hansol.tofu.applicant.domain;
+
+import org.hibernate.annotations.DynamicInsert;
+
+import com.hansol.tofu.clubschedule.domain.ClubScheduleEntity;
+import com.hansol.tofu.global.TimeEntity;
+import com.hansol.tofu.member.domain.MemberEntity;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@Entity
+@Builder
+@DynamicInsert
+@Table(name = "applicant")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ApplicantEntity extends TimeEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@JoinColumn(name = "club_schedule_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	private ClubScheduleEntity clubSchedule;
+
+	@JoinColumn(name = "member_id")
+	@OneToOne(fetch = FetchType.LAZY)
+	private MemberEntity member;
+
+}

--- a/src/main/java/com/hansol/tofu/applicant/repository/ApplicantRepository.java
+++ b/src/main/java/com/hansol/tofu/applicant/repository/ApplicantRepository.java
@@ -1,0 +1,8 @@
+package com.hansol.tofu.applicant.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.hansol.tofu.applicant.domain.ApplicantEntity;
+
+public interface ApplicantRepository extends JpaRepository<ApplicantEntity, Long> {
+}

--- a/src/main/java/com/hansol/tofu/auth/EmailVerificationService.java
+++ b/src/main/java/com/hansol/tofu/auth/EmailVerificationService.java
@@ -8,6 +8,8 @@ import com.hansol.tofu.error.BaseException;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
 import org.springframework.web.util.UriComponentsBuilder;
 
@@ -24,6 +26,7 @@ public class EmailVerificationService {
 
     private final HttpServletRequest httpServletRequest;
 
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
     public void verifyEmail(String email) {
 
         String code = createCode();

--- a/src/main/java/com/hansol/tofu/auth/email/EmailSenderServiceImpl.java
+++ b/src/main/java/com/hansol/tofu/auth/email/EmailSenderServiceImpl.java
@@ -24,6 +24,7 @@ public class EmailSenderServiceImpl implements EmailSenderService {
 
         try {
             var mimeMessageHelper = new MimeMessageHelper(mimeMessage, true);
+			mimeMessageHelper.setFrom("no-reply@hansol.com");
             mimeMessageHelper.setTo(emailRequestDTO.to());
             mimeMessageHelper.setSubject(emailRequestDTO.subject());
             mimeMessageHelper.setText(emailRequestDTO.content());

--- a/src/main/java/com/hansol/tofu/club/annotation/IsManager.java
+++ b/src/main/java/com/hansol/tofu/club/annotation/IsManager.java
@@ -9,6 +9,6 @@ import java.lang.annotation.Target;
 
 @Target({ElementType.METHOD, ElementType.TYPE})
 @Retention(RetentionPolicy.RUNTIME)
-@PreAuthorize("@clubAuth.decide(#root, #cludId, T(com.hansol.tofu.club.enums.ClubRole).MANAGER.name())")
+@PreAuthorize("@clubAuth.decide(#root, #clubId, T(com.hansol.tofu.club.enums.ClubRole).MANAGER.name())")
 public @interface IsManager {
 }

--- a/src/main/java/com/hansol/tofu/clubschedule/ClubScheduleService.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/ClubScheduleService.java
@@ -1,15 +1,18 @@
 package com.hansol.tofu.clubschedule;
 
 import com.hansol.tofu.club.repository.ClubRepository;
-import com.hansol.tofu.clubschedule.domain.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.clubschedule.domain.dto.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.clubschedule.domain.dto.ClubScheduleEditRequestDTO;
 import com.hansol.tofu.clubschedule.repository.ClubScheduleRepository;
 import com.hansol.tofu.error.BaseException;
-import com.hansol.tofu.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.SQLException;
+
+import static com.hansol.tofu.error.ErrorCode.NOT_FOUND_CLUB;
+import static com.hansol.tofu.error.ErrorCode.NOT_FOUND_CLUB_SCHEDULE;
 
 @Service
 @RequiredArgsConstructor
@@ -21,12 +24,19 @@ public class ClubScheduleService {
 
 	public Long addClubSchedule(Long clubId, ClubScheduleCreationRequestDTO clubScheduleCreationRequestDTO) {
 		var clubEntity = clubRepository.findById(clubId)
-				.orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_CLUB));
+				.orElseThrow(() -> new BaseException(NOT_FOUND_CLUB));
 
 		var clubScheduleEntity = clubScheduleCreationRequestDTO
 				.toEntity(clubScheduleCreationRequestDTO, clubEntity);
 
 		return clubScheduleRepository.save(clubScheduleEntity).getId();
+	}
+
+	public void editClubSchedule(Long scheduleId, ClubScheduleEditRequestDTO clubScheduleEditRequestDTO) {
+		var clubScheduleEntity = clubScheduleRepository.findById(scheduleId)
+				.orElseThrow(() -> new BaseException(NOT_FOUND_CLUB_SCHEDULE));
+
+		clubScheduleEntity.changeClubSchedule(clubScheduleEditRequestDTO);
 	}
 
 }

--- a/src/main/java/com/hansol/tofu/clubschedule/ClubScheduleService.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/ClubScheduleService.java
@@ -1,7 +1,10 @@
 package com.hansol.tofu.clubschedule;
 
+import com.hansol.tofu.club.repository.ClubRepository;
 import com.hansol.tofu.clubschedule.domain.ClubScheduleCreationRequestDTO;
 import com.hansol.tofu.clubschedule.repository.ClubScheduleRepository;
+import com.hansol.tofu.error.BaseException;
+import com.hansol.tofu.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -14,9 +17,14 @@ import java.sql.SQLException;
 public class ClubScheduleService {
 
 	private final ClubScheduleRepository clubScheduleRepository;
+	private final ClubRepository clubRepository;
 
-	public Long addClubSchedule(ClubScheduleCreationRequestDTO clubScheduleCreationRequestDTO) {
-		var clubScheduleEntity = clubScheduleCreationRequestDTO.toEntity(clubScheduleCreationRequestDTO);
+	public Long addClubSchedule(Long clubId, ClubScheduleCreationRequestDTO clubScheduleCreationRequestDTO) {
+		var clubEntity = clubRepository.findById(clubId)
+				.orElseThrow(() -> new BaseException(ErrorCode.NOT_FOUND_CLUB));
+
+		var clubScheduleEntity = clubScheduleCreationRequestDTO
+				.toEntity(clubScheduleCreationRequestDTO, clubEntity);
 
 		return clubScheduleRepository.save(clubScheduleEntity).getId();
 	}

--- a/src/main/java/com/hansol/tofu/clubschedule/ClubScheduleService.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/ClubScheduleService.java
@@ -1,13 +1,12 @@
 package com.hansol.tofu.clubschedule;
 
-import java.sql.SQLException;
-
+import com.hansol.tofu.clubschedule.domain.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.clubschedule.repository.ClubScheduleRepository;
+import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.hansol.tofu.clubschedule.repository.ClubScheduleRepository;
-
-import lombok.RequiredArgsConstructor;
+import java.sql.SQLException;
 
 @Service
 @RequiredArgsConstructor
@@ -15,5 +14,11 @@ import lombok.RequiredArgsConstructor;
 public class ClubScheduleService {
 
 	private final ClubScheduleRepository clubScheduleRepository;
+
+	public Long addClubSchedule(ClubScheduleCreationRequestDTO clubScheduleCreationRequestDTO) {
+		var clubScheduleEntity = clubScheduleCreationRequestDTO.toEntity(clubScheduleCreationRequestDTO);
+
+		return clubScheduleRepository.save(clubScheduleEntity).getId();
+	}
 
 }

--- a/src/main/java/com/hansol/tofu/clubschedule/ClubScheduleService.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/ClubScheduleService.java
@@ -39,4 +39,11 @@ public class ClubScheduleService {
 		clubScheduleEntity.changeClubSchedule(clubScheduleEditRequestDTO);
 	}
 
+	public void deleteClubSchedule(Long scheduleId) {
+		var clubScheduleEntity = clubScheduleRepository.findById(scheduleId)
+				.orElseThrow(() -> new BaseException(NOT_FOUND_CLUB_SCHEDULE));
+
+		clubScheduleEntity.deleteClubSchedule();
+	}
+
 }

--- a/src/main/java/com/hansol/tofu/clubschedule/ClubScheduleService.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/ClubScheduleService.java
@@ -1,0 +1,19 @@
+package com.hansol.tofu.clubschedule;
+
+import java.sql.SQLException;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.hansol.tofu.clubschedule.repository.ClubScheduleRepository;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(rollbackFor = SQLException.class)
+public class ClubScheduleService {
+
+	private final ClubScheduleRepository clubScheduleRepository;
+
+}

--- a/src/main/java/com/hansol/tofu/clubschedule/controller/ClubScheduleController.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/controller/ClubScheduleController.java
@@ -1,0 +1,21 @@
+package com.hansol.tofu.clubschedule.controller;
+
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.hansol.tofu.clubschedule.ClubScheduleService;
+
+import io.swagger.v3.oas.annotations.security.SecurityRequirement;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+
+@SecurityRequirement(name = "Bearer Authentication")
+@Tag(name = "club-schedule", description = "동호회 모임일정 API")
+@RestController
+@RequestMapping("/api/club-schedule")
+@RequiredArgsConstructor
+public class ClubScheduleController {
+
+	private final ClubScheduleService clubScheduleService;
+
+}

--- a/src/main/java/com/hansol/tofu/clubschedule/controller/ClubScheduleController.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/controller/ClubScheduleController.java
@@ -1,8 +1,9 @@
 package com.hansol.tofu.clubschedule.controller;
 
-import com.hansol.tofu.club.annotation.IsManager;
+import com.hansol.tofu.club.annotation.IsPresident;
 import com.hansol.tofu.clubschedule.ClubScheduleService;
-import com.hansol.tofu.clubschedule.domain.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.clubschedule.domain.dto.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.clubschedule.domain.dto.ClubScheduleEditRequestDTO;
 import com.hansol.tofu.global.BaseHttpResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -25,14 +26,29 @@ public class ClubScheduleController {
 
 
     @Operation(summary = "모임일정 추가 API", responses = {
-   		@ApiResponse(responseCode = "200", description = "모임일정 추가 성공", content = @Content(schema = @Schema(implementation = Long.class))),
-        @ApiResponse(responseCode = "400", description = "요청값 에러", content = @Content(schema = @Schema(implementation = BaseHttpResponse.class))),
-        @ApiResponse(responseCode = "404", description = "존재하지 않는 동호회", content = @Content(schema = @Schema(implementation = Long.class))),
-   	})
-    @IsManager
+            @ApiResponse(responseCode = "200", description = "모임일정 추가 성공", content = @Content(schema = @Schema(implementation = Long.class))),
+            @ApiResponse(responseCode = "400", description = "요청값 에러", content = @Content(schema = @Schema(implementation = BaseHttpResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 동호회", content = @Content(schema = @Schema(implementation = Long.class))),
+    })
+    @IsPresident
     @PostMapping("/{clubId}/schedules")
     public BaseHttpResponse<Long> addClubSchedule(@PathVariable Long clubId, @RequestBody @Valid ClubScheduleCreationRequestDTO clubScheduleCreationRequestDTO) {
         return BaseHttpResponse.success(clubScheduleService.addClubSchedule(clubId, clubScheduleCreationRequestDTO));
+    }
+
+    @Operation(summary = "모임일정 변경 API", responses = {
+            @ApiResponse(responseCode = "200", description = "모임일정 변경 성공", content = @Content(schema = @Schema(implementation = Long.class))),
+            @ApiResponse(responseCode = "400", description = "요청값 에러", content = @Content(schema = @Schema(implementation = BaseHttpResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임일정", content = @Content(schema = @Schema(implementation = Long.class))),
+    })
+    @IsPresident
+    @PatchMapping("/{clubId}/schedules/{scheduleId}")
+    public BaseHttpResponse<?> editClubSchedule(@PathVariable Long clubId,
+                                                @PathVariable Long scheduleId,
+                                                @RequestBody @Valid ClubScheduleEditRequestDTO clubScheduleEditRequestDTO
+    ) {
+        clubScheduleService.editClubSchedule(scheduleId, clubScheduleEditRequestDTO);
+        return BaseHttpResponse.successWithNoContent();
     }
 
 }

--- a/src/main/java/com/hansol/tofu/clubschedule/controller/ClubScheduleController.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/controller/ClubScheduleController.java
@@ -1,13 +1,20 @@
 package com.hansol.tofu.clubschedule.controller;
 
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
-
 import com.hansol.tofu.clubschedule.ClubScheduleService;
-
+import com.hansol.tofu.clubschedule.domain.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.global.BaseHttpResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @SecurityRequirement(name = "Bearer Authentication")
 @Tag(name = "club-schedule", description = "동호회 모임일정 API")
@@ -16,6 +23,16 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class ClubScheduleController {
 
-	private final ClubScheduleService clubScheduleService;
+    private final ClubScheduleService clubScheduleService;
+
+
+    @Operation(summary = "모임일정 추가 API", responses = {
+   		@ApiResponse(responseCode = "200", description = "모임일정 추가 성공", content = @Content(schema = @Schema(implementation = Long.class))),
+   		@ApiResponse(responseCode = "400", description = "요청값 에러", content = @Content(schema = @Schema(implementation = BaseHttpResponse.class))),
+   	})
+    @PostMapping
+    public BaseHttpResponse<Long> addClubSchedule(@RequestBody @Valid ClubScheduleCreationRequestDTO clubScheduleCreationRequestDTO) {
+        return BaseHttpResponse.success(clubScheduleService.addClubSchedule(clubScheduleCreationRequestDTO));
+    }
 
 }

--- a/src/main/java/com/hansol/tofu/clubschedule/controller/ClubScheduleController.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/controller/ClubScheduleController.java
@@ -51,4 +51,18 @@ public class ClubScheduleController {
         return BaseHttpResponse.successWithNoContent();
     }
 
+    @Operation(summary = "모임일정 삭제 API", responses = {
+            @ApiResponse(responseCode = "200", description = "모임일정 변경 성공", content = @Content(schema = @Schema(implementation = Long.class))),
+            @ApiResponse(responseCode = "400", description = "요청값 에러", content = @Content(schema = @Schema(implementation = BaseHttpResponse.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 모임일정", content = @Content(schema = @Schema(implementation = Long.class))),
+    })
+    @IsPresident
+    @DeleteMapping("/{clubId}/schedules/{scheduleId}")
+    public BaseHttpResponse<?> deleteClubSchedule(@PathVariable Long clubId,
+                                                @PathVariable Long scheduleId
+    ) {
+        clubScheduleService.deleteClubSchedule(scheduleId);
+        return BaseHttpResponse.successWithNoContent();
+    }
+
 }

--- a/src/main/java/com/hansol/tofu/clubschedule/controller/ClubScheduleController.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/controller/ClubScheduleController.java
@@ -1,5 +1,6 @@
 package com.hansol.tofu.clubschedule.controller;
 
+import com.hansol.tofu.club.annotation.IsManager;
 import com.hansol.tofu.clubschedule.ClubScheduleService;
 import com.hansol.tofu.clubschedule.domain.ClubScheduleCreationRequestDTO;
 import com.hansol.tofu.global.BaseHttpResponse;
@@ -11,16 +12,13 @@ import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @SecurityRequirement(name = "Bearer Authentication")
 @Tag(name = "club-schedule", description = "동호회 모임일정 API")
 @RestController
-@RequestMapping("/api/club-schedule")
 @RequiredArgsConstructor
+@RequestMapping("/api/clubs")
 public class ClubScheduleController {
 
     private final ClubScheduleService clubScheduleService;
@@ -28,11 +26,13 @@ public class ClubScheduleController {
 
     @Operation(summary = "모임일정 추가 API", responses = {
    		@ApiResponse(responseCode = "200", description = "모임일정 추가 성공", content = @Content(schema = @Schema(implementation = Long.class))),
-   		@ApiResponse(responseCode = "400", description = "요청값 에러", content = @Content(schema = @Schema(implementation = BaseHttpResponse.class))),
+        @ApiResponse(responseCode = "400", description = "요청값 에러", content = @Content(schema = @Schema(implementation = BaseHttpResponse.class))),
+        @ApiResponse(responseCode = "404", description = "존재하지 않는 동호회", content = @Content(schema = @Schema(implementation = Long.class))),
    	})
-    @PostMapping
-    public BaseHttpResponse<Long> addClubSchedule(@RequestBody @Valid ClubScheduleCreationRequestDTO clubScheduleCreationRequestDTO) {
-        return BaseHttpResponse.success(clubScheduleService.addClubSchedule(clubScheduleCreationRequestDTO));
+    @IsManager
+    @PostMapping("/{clubId}/schedules")
+    public BaseHttpResponse<Long> addClubSchedule(@PathVariable Long clubId, @RequestBody @Valid ClubScheduleCreationRequestDTO clubScheduleCreationRequestDTO) {
+        return BaseHttpResponse.success(clubScheduleService.addClubSchedule(clubId, clubScheduleCreationRequestDTO));
     }
 
 }

--- a/src/main/java/com/hansol/tofu/clubschedule/domain/ClubScheduleCreationRequestDTO.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/domain/ClubScheduleCreationRequestDTO.java
@@ -1,5 +1,6 @@
 package com.hansol.tofu.clubschedule.domain;
 
+import com.hansol.tofu.club.domain.entity.ClubEntity;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;
@@ -19,11 +20,12 @@ public record ClubScheduleCreationRequestDTO(
     public ClubScheduleCreationRequestDTO {
     }
 
-    public ClubScheduleEntity toEntity(ClubScheduleCreationRequestDTO schedule) {
+    public ClubScheduleEntity toEntity(ClubScheduleCreationRequestDTO schedule, ClubEntity club) {
         return ClubScheduleEntity.builder()
                 .title(schedule.title())
                 .content(schedule.content())
                 .eventAt(ZonedDateTime.of(schedule.eventAt(), ZoneId.of("Asia/Seoul")))
+                .club(club)
                 .build();
     }
 }

--- a/src/main/java/com/hansol/tofu/clubschedule/domain/ClubScheduleCreationRequestDTO.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/domain/ClubScheduleCreationRequestDTO.java
@@ -1,0 +1,29 @@
+package com.hansol.tofu.clubschedule.domain;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+
+public record ClubScheduleCreationRequestDTO(
+        @NotBlank(message = "제목을 입력해주세요")
+        String title,
+        String content,
+        @Future(message = "현재 시간 이후의 일정만 등록할 수 있습니다")
+        LocalDateTime eventAt
+) {
+    @Builder
+    public ClubScheduleCreationRequestDTO {
+    }
+
+    public ClubScheduleEntity toEntity(ClubScheduleCreationRequestDTO schedule) {
+        return ClubScheduleEntity.builder()
+                .title(schedule.title())
+                .content(schedule.content())
+                .eventAt(ZonedDateTime.of(schedule.eventAt(), ZoneId.of("Asia/Seoul")))
+                .build();
+    }
+}

--- a/src/main/java/com/hansol/tofu/clubschedule/domain/ClubScheduleEntity.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/domain/ClubScheduleEntity.java
@@ -1,6 +1,7 @@
 package com.hansol.tofu.clubschedule.domain;
 
 import com.hansol.tofu.club.domain.entity.ClubEntity;
+import com.hansol.tofu.clubschedule.domain.dto.ClubScheduleEditRequestDTO;
 import com.hansol.tofu.clubschedule.enums.ClubScheduleStatus;
 import com.hansol.tofu.global.TimeEntity;
 import jakarta.persistence.*;
@@ -8,6 +9,7 @@ import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.DynamicInsert;
 
+import java.time.ZoneId;
 import java.time.ZonedDateTime;
 
 @Getter
@@ -40,5 +42,11 @@ public class ClubScheduleEntity extends TimeEntity {
 	@JoinColumn(name = "club_id")
 	@ManyToOne(fetch = FetchType.LAZY)
 	private ClubEntity club;
+
+	public void changeClubSchedule(ClubScheduleEditRequestDTO clubSchedule) {
+		this.title = clubSchedule.title();
+		this.content = clubSchedule.content();
+		this.eventAt = ZonedDateTime.of(clubSchedule.eventAt(), ZoneId.of("Asia/Seoul"));
+	}
 
 }

--- a/src/main/java/com/hansol/tofu/clubschedule/domain/ClubScheduleEntity.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/domain/ClubScheduleEntity.java
@@ -49,4 +49,8 @@ public class ClubScheduleEntity extends TimeEntity {
 		this.eventAt = ZonedDateTime.of(clubSchedule.eventAt(), ZoneId.of("Asia/Seoul"));
 	}
 
+	public void deleteClubSchedule() {
+		this.clubScheduleStatus = ClubScheduleStatus.DELETED;
+	}
+
 }

--- a/src/main/java/com/hansol/tofu/clubschedule/domain/ClubScheduleEntity.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/domain/ClubScheduleEntity.java
@@ -1,0 +1,61 @@
+package com.hansol.tofu.clubschedule.domain;
+
+import java.time.ZonedDateTime;
+
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
+
+import com.hansol.tofu.club.domain.entity.ClubEntity;
+import com.hansol.tofu.clubschedule.enums.ClubScheduleStatus;
+import com.hansol.tofu.global.TimeEntity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@EqualsAndHashCode(callSuper = false)
+@Entity
+@Builder
+@DynamicInsert
+@Table(name = "club_schedule")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class ClubScheduleEntity extends TimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@Column(nullable = false, name = "event_at")
+	private ZonedDateTime eventAt;
+
+	@Column(nullable = false)
+	private String title;
+
+	@Column(nullable = false)
+	private String content;
+
+	@Enumerated(EnumType.STRING)
+	@Column(name = "status", nullable = false)
+	@ColumnDefault("RECRUITING")
+	private ClubScheduleStatus clubScheduleStatus;
+
+	@JoinColumn(name = "club_id")
+	@ManyToOne(fetch = FetchType.LAZY)
+	private ClubEntity club;
+
+}

--- a/src/main/java/com/hansol/tofu/clubschedule/domain/ClubScheduleEntity.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/domain/ClubScheduleEntity.java
@@ -1,31 +1,14 @@
 package com.hansol.tofu.clubschedule.domain;
 
-import java.time.ZonedDateTime;
-
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.DynamicInsert;
-
 import com.hansol.tofu.club.domain.entity.ClubEntity;
 import com.hansol.tofu.clubschedule.enums.ClubScheduleStatus;
 import com.hansol.tofu.global.TimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicInsert;
 
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.EnumType;
-import jakarta.persistence.Enumerated;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.EqualsAndHashCode;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import java.time.ZonedDateTime;
 
 @Getter
 @EqualsAndHashCode(callSuper = false)

--- a/src/main/java/com/hansol/tofu/clubschedule/domain/dto/ClubScheduleCreationRequestDTO.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/domain/dto/ClubScheduleCreationRequestDTO.java
@@ -1,6 +1,7 @@
-package com.hansol.tofu.clubschedule.domain;
+package com.hansol.tofu.clubschedule.domain.dto;
 
 import com.hansol.tofu.club.domain.entity.ClubEntity;
+import com.hansol.tofu.clubschedule.domain.ClubScheduleEntity;
 import jakarta.validation.constraints.Future;
 import jakarta.validation.constraints.NotBlank;
 import lombok.Builder;

--- a/src/main/java/com/hansol/tofu/clubschedule/domain/dto/ClubScheduleEditRequestDTO.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/domain/dto/ClubScheduleEditRequestDTO.java
@@ -1,0 +1,19 @@
+package com.hansol.tofu.clubschedule.domain.dto;
+
+import jakarta.validation.constraints.Future;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+public record ClubScheduleEditRequestDTO(
+        @NotBlank(message = "제목을 입력해주세요")
+        String title,
+        String content,
+        @Future(message = "현재 시간 이후의 일정만 등록할 수 있습니다")
+        LocalDateTime eventAt
+) {
+    @Builder
+    public ClubScheduleEditRequestDTO {
+    }
+}

--- a/src/main/java/com/hansol/tofu/clubschedule/enums/ClubScheduleStatus.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/enums/ClubScheduleStatus.java
@@ -1,0 +1,5 @@
+package com.hansol.tofu.clubschedule.enums;
+
+public enum ClubScheduleStatus {
+	RECRUITING, CLOSED, DELETED
+}

--- a/src/main/java/com/hansol/tofu/clubschedule/repository/ClubScheduleRepository.java
+++ b/src/main/java/com/hansol/tofu/clubschedule/repository/ClubScheduleRepository.java
@@ -1,0 +1,8 @@
+package com.hansol.tofu.clubschedule.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.hansol.tofu.clubschedule.domain.ClubScheduleEntity;
+
+public interface ClubScheduleRepository extends JpaRepository<ClubScheduleEntity, Long> {
+}

--- a/src/main/java/com/hansol/tofu/config/security/SecurityConfig.java
+++ b/src/main/java/com/hansol/tofu/config/security/SecurityConfig.java
@@ -46,7 +46,7 @@ public class SecurityConfig {
 	@Bean
 	public WebSecurityCustomizer webSecurityCustomizer() {
 		return (web) -> web.ignoring()
-			.requestMatchers("/api/auth/**", "/favicon.ico", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html");
+			.requestMatchers("/", "/promotion", "/api/auth/**", "/favicon.ico", "/swagger-ui/**", "/v3/api-docs/**", "/swagger-ui.html");
 	}
 
 	// https://docs.spring.io/spring-security/reference/servlet/authorization/architecture.html

--- a/src/main/java/com/hansol/tofu/error/ErrorCode.java
+++ b/src/main/java/com/hansol/tofu/error/ErrorCode.java
@@ -21,6 +21,7 @@ public enum ErrorCode {
 	NOT_FOUND_CATEGORY(HttpStatus.NOT_FOUND, "카테고리 정보를 찾을 수 없습니다"),
 	NOT_FOUND_CLUB(HttpStatus.NOT_FOUND, "동호회 정보를 찾을 수 없습니다"),
 	NOT_FOUND_CLUB_MEMBER(HttpStatus.NOT_FOUND, "해당 동호회에 가입 혹은 가입요청된 회원 정보를 찾을 수 없습니다"),
+	NOT_FOUND_CLUB_SCHEDULE(HttpStatus.NOT_FOUND, "동호회 모임일정 정보를 찾을 수 없습니다"),
 
 
 	FAILED_TO_SEND_EMAIL(HttpStatus.INTERNAL_SERVER_ERROR, "이메일 전송에 실패하였습니다"),

--- a/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleAuthorityTest.java
+++ b/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleAuthorityTest.java
@@ -2,7 +2,8 @@ package com.hansol.tofu.clubschedule;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
-import com.hansol.tofu.clubschedule.domain.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.clubschedule.domain.dto.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.clubschedule.domain.dto.ClubScheduleEditRequestDTO;
 import com.hansol.tofu.clubschedule.mock.WithMockCustomUser;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.Disabled;
@@ -12,10 +13,10 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 
 import java.time.LocalDateTime;
 
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -52,7 +53,6 @@ public class ClubScheduleAuthorityTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(clubScheduleCreationRequestDTO)))
-                .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().is5xxServerError())
                 .andExpect(jsonPath("$.message", Matchers.is("Access Denied")));
     }
@@ -71,7 +71,62 @@ public class ClubScheduleAuthorityTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(clubScheduleCreationRequestDTO)))
-                .andDo(MockMvcResultHandlers.print())
                 .andExpect(status().isOk());
     }
+
+    @Test
+    @WithMockCustomUser(username = "lisa@test.com")
+    void addClubSchedule_총무_권한으로_모임일정_등록시_등록에_실패한다() throws Exception {
+        var clubScheduleCreationRequestDTO = ClubScheduleCreationRequestDTO.builder()
+                .eventAt(LocalDateTime.now().plusHours(1))
+                .title("한솔두부")
+                .content("한솔두부모임")
+                .build();
+
+
+        mvc.perform(post("/api/clubs/{clubId}/schedules", 2L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(clubScheduleCreationRequestDTO)))
+                .andExpect(status().is5xxServerError())
+                .andExpect(jsonPath("$.message", Matchers.is("Access Denied")));
+    }
+
+    @Test
+    @WithMockCustomUser(username = "lisa@test.com")
+    void editClubSchedule_총무_권한으로_모임일정_변경시_변경에_실패한다() throws Exception {
+        var newEventAt = LocalDateTime.now().plusHours(1);
+        var clubScheduleEditRequestDTO = ClubScheduleEditRequestDTO.builder()
+                .eventAt(newEventAt)
+                .title("변경된한솔두부모임")
+                .content("변경된한솔두부모임입니다")
+                .build();
+
+
+        mvc.perform(patch("/api/clubs/{clubId}/schedules/2", 2L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(clubScheduleEditRequestDTO)))
+                .andExpect(status().is5xxServerError())
+                .andExpect(jsonPath("$.message", Matchers.is("Access Denied")));
+    }
+
+    @Test
+    @WithMockCustomUser(username = "lisa@test.com")
+    void editClubSchedule_동호회장_권한으로_모임일정_변경시_변경에_성공한다() throws Exception {
+        var newEventAt = LocalDateTime.now().plusHours(1);
+        var clubScheduleCreationRequestDTO = ClubScheduleCreationRequestDTO.builder()
+                .eventAt(newEventAt)
+                .title("변경된한솔두부모임")
+                .content("변경된한솔두부모임입니다")
+                .build();
+
+
+        mvc.perform(patch("/api/clubs/{clubId}/schedules/2", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(clubScheduleCreationRequestDTO)))
+                .andExpect(status().isOk());
+    }
+
 }

--- a/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleAuthorityTest.java
+++ b/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleAuthorityTest.java
@@ -16,8 +16,7 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.time.LocalDateTime;
 
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -127,6 +126,33 @@ public class ClubScheduleAuthorityTest {
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(clubScheduleCreationRequestDTO)))
                 .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockCustomUser(username = "lisa@test.com")
+    void editClubSchedule_동호회장_권한으로_모임일정_삭제에_성공한다() throws Exception {
+        Long clubIdAsPresident = 1L;
+        Long scheduleId = 2L;
+
+
+        mvc.perform(delete("/api/clubs/" + clubIdAsPresident + "/schedules/" + scheduleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @WithMockCustomUser(username = "lisa@test.com")
+    void editClubSchedule_총무_권한으로_모임일정_삭제에_성공한다() throws Exception {
+        Long clubIdAsManager = 2L;
+        Long scheduleId = 2L;
+
+
+        mvc.perform(delete("/api/clubs/" + clubIdAsManager + "/schedules/" + scheduleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().is5xxServerError())
+                .andExpect(jsonPath("$.message", Matchers.is("Access Denied")));
     }
 
 }

--- a/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleControllerTest.java
+++ b/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleControllerTest.java
@@ -10,6 +10,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultHandlers;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.time.LocalDateTime;
@@ -19,9 +20,11 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+
 public class ClubScheduleControllerTest {
 
     private MockMvc client;
+
     private ClubScheduleService clubScheduleService;
 
     private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
@@ -29,7 +32,8 @@ public class ClubScheduleControllerTest {
     @BeforeEach
     void setUp() {
         clubScheduleService = mock(ClubScheduleService.class);
-        client = MockMvcBuilders.standaloneSetup(new ClubScheduleController(clubScheduleService))
+        client = MockMvcBuilders
+                .standaloneSetup(new ClubScheduleController(clubScheduleService))
                 .setControllerAdvice(new BaseExceptionHandler())
                 .build();
     }
@@ -38,15 +42,16 @@ public class ClubScheduleControllerTest {
     void addClubSchedule_모임일정추가요청시_성공한다() throws Exception {
         var clubScheduleCreationRequestDTO = ClubScheduleCreationRequestDTO.builder()
                 .eventAt(LocalDateTime.now().plusHours(1L))
-                .title("두부먹는모임")
-                .content("두부먹는모임입니다")
+                .title("한솔두부")
+                .content("한솔두부모임")
                 .build();
 
-        client.perform(post("/api/club-schedule")
-                .contentType(MediaType.APPLICATION_JSON)
-                .accept(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(clubScheduleCreationRequestDTO)))
-            .andExpect(status().isOk());
+        client.perform(post("/api/clubs/{clubId}/schedules", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(clubScheduleCreationRequestDTO)))
+                .andDo(MockMvcResultHandlers.print())
+                .andExpect(status().isOk());
     }
 
 
@@ -54,12 +59,12 @@ public class ClubScheduleControllerTest {
     void addClubSchedule_과거시간으로_모임추가시_예외가_발생한다() throws Exception {
         var clubScheduleCreationRequestDTO = ClubScheduleCreationRequestDTO.builder()
                 .eventAt(LocalDateTime.now().minusHours(1))
-                .title("두부먹는모임")
-                .content("두부먹는모임입니다")
+                .title("한솔두부")
+                .content("한솔두부모임")
                 .build();
 
 
-        client.perform(post("/api/club-schedule")
+        client.perform(post("/api/clubs/{clubId}/schedules", 1L)
                         .contentType(MediaType.APPLICATION_JSON)
                         .accept(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(clubScheduleCreationRequestDTO)))

--- a/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleControllerTest.java
+++ b/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleControllerTest.java
@@ -17,8 +17,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.time.LocalDateTime;
 
 import static org.mockito.Mockito.mock;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -89,5 +88,17 @@ public class ClubScheduleControllerTest {
                         .content(objectMapper.writeValueAsString(clubScheduleEditRequestDTO)))
                 .andExpect(status().isOk());
     }
+
+    @Test
+    void editClubSchedule_모임일정삭제에_성공한다() throws Exception {
+        var scheduleId = 2L;
+
+
+        client.perform(delete("/api/clubs/" + 1L + "/schedules/" + scheduleId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk());
+    }
+
 
 }

--- a/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleControllerTest.java
+++ b/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleControllerTest.java
@@ -1,0 +1,70 @@
+package com.hansol.tofu.clubschedule;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import com.hansol.tofu.clubschedule.controller.ClubScheduleController;
+import com.hansol.tofu.clubschedule.domain.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.error.BaseExceptionHandler;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+public class ClubScheduleControllerTest {
+
+    private MockMvc client;
+    private ClubScheduleService clubScheduleService;
+
+    private final ObjectMapper objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
+
+    @BeforeEach
+    void setUp() {
+        clubScheduleService = mock(ClubScheduleService.class);
+        client = MockMvcBuilders.standaloneSetup(new ClubScheduleController(clubScheduleService))
+                .setControllerAdvice(new BaseExceptionHandler())
+                .build();
+    }
+
+    @Test
+    void addClubSchedule_모임일정추가요청시_성공한다() throws Exception {
+        var clubScheduleCreationRequestDTO = ClubScheduleCreationRequestDTO.builder()
+                .eventAt(LocalDateTime.now().plusHours(1L))
+                .title("두부먹는모임")
+                .content("두부먹는모임입니다")
+                .build();
+
+        client.perform(post("/api/club-schedule")
+                .contentType(MediaType.APPLICATION_JSON)
+                .accept(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(clubScheduleCreationRequestDTO)))
+            .andExpect(status().isOk());
+    }
+
+
+    @Test
+    void addClubSchedule_과거시간으로_모임추가시_예외가_발생한다() throws Exception {
+        var clubScheduleCreationRequestDTO = ClubScheduleCreationRequestDTO.builder()
+                .eventAt(LocalDateTime.now().minusHours(1))
+                .title("두부먹는모임")
+                .content("두부먹는모임입니다")
+                .build();
+
+
+        client.perform(post("/api/club-schedule")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(clubScheduleCreationRequestDTO)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message", Matchers.is("현재 시간 이후의 일정만 등록할 수 있습니다")));
+    }
+
+}

--- a/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleControllerTest.java
+++ b/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleControllerTest.java
@@ -3,7 +3,8 @@ package com.hansol.tofu.clubschedule;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.hansol.tofu.clubschedule.controller.ClubScheduleController;
-import com.hansol.tofu.clubschedule.domain.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.clubschedule.domain.dto.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.clubschedule.domain.dto.ClubScheduleEditRequestDTO;
 import com.hansol.tofu.error.BaseExceptionHandler;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.BeforeEach;
@@ -16,6 +17,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import java.time.LocalDateTime;
 
 import static org.mockito.Mockito.mock;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -70,6 +72,22 @@ public class ClubScheduleControllerTest {
                         .content(objectMapper.writeValueAsString(clubScheduleCreationRequestDTO)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message", Matchers.is("현재 시간 이후의 일정만 등록할 수 있습니다")));
+    }
+
+    @Test
+    void editClubSchedule_모임일정변경에_성공한다() throws Exception {
+        var newEventAt = LocalDateTime.now().plusHours(1);
+        var clubScheduleEditRequestDTO = ClubScheduleEditRequestDTO.builder()
+                .eventAt(newEventAt)
+                .title("변경된한솔두부모임")
+                .content("변경된한솔두부모임입니다")
+                .build();
+
+        client.perform(patch("/api/clubs/{clubId}/schedules/2", 1L)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .accept(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(clubScheduleEditRequestDTO)))
+                .andExpect(status().isOk());
     }
 
 }

--- a/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleServiceTest.java
+++ b/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleServiceTest.java
@@ -1,40 +1,72 @@
 package com.hansol.tofu.clubschedule;
 
+import com.hansol.tofu.club.domain.entity.ClubEntity;
+import com.hansol.tofu.club.repository.ClubRepository;
 import com.hansol.tofu.clubschedule.domain.ClubScheduleCreationRequestDTO;
 import com.hansol.tofu.clubschedule.repository.ClubScheduleRepository;
+import com.hansol.tofu.error.BaseException;
+import com.hansol.tofu.error.ErrorCode;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDateTime;
+import java.util.Optional;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 
+@ExtendWith(SpringExtension.class)
+@ContextConfiguration
 public class ClubScheduleServiceTest {
 
     private ClubScheduleService sut;
     private ClubScheduleRepository clubScheduleRepository;
+    private ClubRepository clubRepository;
 
     @BeforeEach
     void setUp() {
         clubScheduleRepository = mock(ClubScheduleRepository.class);
-        sut = new ClubScheduleService(clubScheduleRepository);
+        clubRepository = mock(ClubRepository.class);
+        sut = new ClubScheduleService(clubScheduleRepository, clubRepository);
     }
 
     @Test
     void addClubSchedule_동호회_모임일정을_추가한다() {
+        var clubEntity = ClubEntity.builder().id(2L).build();
         var clubScheduleCreationRequestDTO = ClubScheduleCreationRequestDTO.builder()
                 .eventAt(LocalDateTime.now().plusHours(1L))
-                .title("두부먹는모임")
-                .content("두부먹는모임입니다")
+                .title("한솔두부모임")
+                .content("한솔두부모임입니다")
                 .build();
-        var clubScheduleEntity = clubScheduleCreationRequestDTO.toEntity(clubScheduleCreationRequestDTO);
+        var clubScheduleEntity = clubScheduleCreationRequestDTO.toEntity(clubScheduleCreationRequestDTO, clubEntity);
+        when(clubRepository.findById(2L)).thenReturn(Optional.of(clubEntity));
         when(clubScheduleRepository.save(clubScheduleEntity)).thenReturn(clubScheduleEntity);
 
 
-        sut.addClubSchedule(clubScheduleCreationRequestDTO);
+        sut.addClubSchedule(2L, clubScheduleCreationRequestDTO);
 
 
         verify(clubScheduleRepository, times(1)).save(clubScheduleEntity);
+    }
+
+    @Test
+    void addClubSchedule_존재하지_않는_동호회에_모임일정_추가시_오류를_반환한다() {
+        var clubScheduleCreationRequestDTO = ClubScheduleCreationRequestDTO.builder()
+                .eventAt(LocalDateTime.now().plusHours(1L))
+                .title("한솔두부모임")
+                .content("한솔두부모임입니다")
+                .build();
+        when(clubRepository.findById(2L)).thenReturn(Optional.empty());
+
+
+        var exception = assertThrows(BaseException.class, () -> sut.addClubSchedule(2L, clubScheduleCreationRequestDTO));
+
+
+        assertEquals(ErrorCode.NOT_FOUND_CLUB.getMessage(), exception.getMessage());
     }
 
 

--- a/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleServiceTest.java
+++ b/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleServiceTest.java
@@ -2,7 +2,9 @@ package com.hansol.tofu.clubschedule;
 
 import com.hansol.tofu.club.domain.entity.ClubEntity;
 import com.hansol.tofu.club.repository.ClubRepository;
-import com.hansol.tofu.clubschedule.domain.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.clubschedule.domain.dto.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.clubschedule.domain.ClubScheduleEntity;
+import com.hansol.tofu.clubschedule.domain.dto.ClubScheduleEditRequestDTO;
 import com.hansol.tofu.clubschedule.repository.ClubScheduleRepository;
 import com.hansol.tofu.error.BaseException;
 import com.hansol.tofu.error.ErrorCode;
@@ -13,6 +15,8 @@ import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Optional;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -67,6 +71,30 @@ public class ClubScheduleServiceTest {
 
 
         assertEquals(ErrorCode.NOT_FOUND_CLUB.getMessage(), exception.getMessage());
+    }
+
+    @Test
+    void editClubSchedule_동호회_모임일정을_변경한다() throws Exception {
+        LocalDateTime newEventAt = LocalDateTime.now().plusHours(1);
+        var clubScheduleEditRequestDTO = ClubScheduleEditRequestDTO.builder()
+                .eventAt(newEventAt)
+                .title("변경된한솔두부모임")
+                .content("변경된한솔두부모임입니다")
+                .build();
+        var clubScheduleEntity = ClubScheduleEntity.builder()
+                .eventAt(ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("Asia/Seoul")))
+                .title("한솔두부모임")
+                .content("한솔두부모임입니다")
+                .build();
+        when(clubScheduleRepository.findById(2L)).thenReturn(Optional.of(clubScheduleEntity));
+
+
+        sut.editClubSchedule(2L, clubScheduleEditRequestDTO);
+
+
+        assertEquals(ZonedDateTime.of(clubScheduleEditRequestDTO.eventAt(), ZoneId.of("Asia/Seoul")), clubScheduleEntity.getEventAt());
+        assertEquals(clubScheduleEditRequestDTO.title(), clubScheduleEntity.getTitle());
+        assertEquals(clubScheduleEditRequestDTO.content(), clubScheduleEntity.getContent());
     }
 
 

--- a/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleServiceTest.java
+++ b/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleServiceTest.java
@@ -1,0 +1,43 @@
+package com.hansol.tofu.clubschedule;
+
+import com.hansol.tofu.clubschedule.domain.ClubScheduleCreationRequestDTO;
+import com.hansol.tofu.clubschedule.repository.ClubScheduleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDateTime;
+
+import static org.mockito.Mockito.*;
+
+public class ClubScheduleServiceTest {
+
+    private ClubScheduleService sut;
+    private ClubScheduleRepository clubScheduleRepository;
+
+    @BeforeEach
+    void setUp() {
+        clubScheduleRepository = mock(ClubScheduleRepository.class);
+        sut = new ClubScheduleService(clubScheduleRepository);
+    }
+
+    @Test
+    void addClubSchedule_동호회_모임일정을_추가한다() {
+        var clubScheduleCreationRequestDTO = ClubScheduleCreationRequestDTO.builder()
+                .eventAt(LocalDateTime.now().plusHours(1L))
+                .title("두부먹는모임")
+                .content("두부먹는모임입니다")
+                .build();
+        var clubScheduleEntity = clubScheduleCreationRequestDTO.toEntity(clubScheduleCreationRequestDTO);
+        when(clubScheduleRepository.save(clubScheduleEntity)).thenReturn(clubScheduleEntity);
+
+
+        sut.addClubSchedule(clubScheduleCreationRequestDTO);
+
+
+        verify(clubScheduleRepository, times(1)).save(clubScheduleEntity);
+    }
+
+
+
+
+}

--- a/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleServiceTest.java
+++ b/src/test/java/com/hansol/tofu/clubschedule/ClubScheduleServiceTest.java
@@ -5,6 +5,7 @@ import com.hansol.tofu.club.repository.ClubRepository;
 import com.hansol.tofu.clubschedule.domain.dto.ClubScheduleCreationRequestDTO;
 import com.hansol.tofu.clubschedule.domain.ClubScheduleEntity;
 import com.hansol.tofu.clubschedule.domain.dto.ClubScheduleEditRequestDTO;
+import com.hansol.tofu.clubschedule.enums.ClubScheduleStatus;
 import com.hansol.tofu.clubschedule.repository.ClubScheduleRepository;
 import com.hansol.tofu.error.BaseException;
 import com.hansol.tofu.error.ErrorCode;
@@ -95,6 +96,24 @@ public class ClubScheduleServiceTest {
         assertEquals(ZonedDateTime.of(clubScheduleEditRequestDTO.eventAt(), ZoneId.of("Asia/Seoul")), clubScheduleEntity.getEventAt());
         assertEquals(clubScheduleEditRequestDTO.title(), clubScheduleEntity.getTitle());
         assertEquals(clubScheduleEditRequestDTO.content(), clubScheduleEntity.getContent());
+    }
+
+    @Test
+    void deleteClubSchedule_동호회_모임일정을_삭제한다() throws Exception {
+        var clubScheduleEntity = ClubScheduleEntity.builder()
+                .id(2L)
+                .eventAt(ZonedDateTime.of(LocalDateTime.now(), ZoneId.of("Asia/Seoul")))
+                .title("한솔두부모임")
+                .content("한솔두부모임입니다")
+                .clubScheduleStatus(ClubScheduleStatus.RECRUITING)
+                .build();
+        when(clubScheduleRepository.findById(2L)).thenReturn(Optional.of(clubScheduleEntity));
+
+
+        sut.deleteClubSchedule(2L);
+
+
+        assertEquals(clubScheduleEntity.getClubScheduleStatus(), ClubScheduleStatus.DELETED);
     }
 
 

--- a/src/test/java/com/hansol/tofu/clubschedule/mock/WithMockCustomUser.java
+++ b/src/test/java/com/hansol/tofu/clubschedule/mock/WithMockCustomUser.java
@@ -1,0 +1,14 @@
+package com.hansol.tofu.clubschedule.mock;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockCustomUserSecurityContextFactory.class)
+public @interface WithMockCustomUser {
+    String username() default "lisa@test.com";
+
+    String name() default "Lisa";
+}

--- a/src/test/java/com/hansol/tofu/clubschedule/mock/WithMockCustomUserSecurityContextFactory.java
+++ b/src/test/java/com/hansol/tofu/clubschedule/mock/WithMockCustomUserSecurityContextFactory.java
@@ -1,0 +1,37 @@
+package com.hansol.tofu.clubschedule.mock;
+
+import com.hansol.tofu.auth.domain.model.CustomUserDetails;
+import com.hansol.tofu.club.domain.dto.ClubAuthorizationDTO;
+import com.hansol.tofu.club.enums.ClubRole;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.List;
+import java.util.Map;
+
+public class WithMockCustomUserSecurityContextFactory implements WithSecurityContextFactory<WithMockCustomUser> {
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockCustomUser annotation) {
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+
+        CustomUserDetails principal =
+                new CustomUserDetails(
+                        "lisa@test.com",
+                        "test1234",
+                        1L,
+                        List.of("ROLE_USER"),
+                        Map.of(
+                                1L, ClubAuthorizationDTO.builder().clubId(1L).clubRole(ClubRole.PRESIDENT).build(),
+                                2L, ClubAuthorizationDTO.builder().clubId(2L).clubRole(ClubRole.MANAGER).build(),
+                                3L, ClubAuthorizationDTO.builder().clubId(3L).clubRole(ClubRole.MEMBER).build()
+                        )
+                );
+        var authentication =
+                new UsernamePasswordAuthenticationToken(principal, "password", principal.getAuthorities());
+        context.setAuthentication(authentication);
+        return context;
+    }
+}


### PR DESCRIPTION
### Assignee*
- @seominah 

### Github Project*
- https://github.com/tofu-hansol/tofu-backend/issues/40
- https://github.com/tofu-hansol/tofu-backend/issues/41
- https://github.com/tofu-hansol/tofu-backend/issues/42

### PR Summary*
- 동호회 모임일정 api

### PR Detail Descriptions*
- 동호회 모임일정 생성
- 동호회 모임일정 수정
- 동호회 모임일정 삭제
- 동호회 모임일정 권한 테스트코드